### PR TITLE
Fix for user identification issues

### DIFF
--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -15,7 +15,7 @@ module.exports = async (reaction, user) => {
   let mcusername = reaction.message.embeds[0].fields[0].value; // shadowolfyt
   let server = reaction.message.embeds[0].fields[1].value; // servers
   let discordid = reaction.message.embeds[0].fields[3].value; // discord id
-  let requesteduser = message.guild.fetchMember(discordid);
+  let requesteduser = message.guild.memebers.fetch(discordid);
   // let requesteduser = client.users.get(discordid);
 
   if (emoji.name == '✅') {


### PR DESCRIPTION
Previously getting `UnhandledPromiseRejectionWarning: TypeError: requesteduser.send is not a function`  from `events\messageReactionAdd.js` line 24. This was likely due to the fact that on line 18, there is no `Guild.fetchMember()` method.

There is a `Guild` class property called `Guild.members`, which has a method [`Guild.members.fetch()`](https://discord.js.org/#/docs/main/stable/class/GuildMemberManager?scrollTo=fetch), which I believe is the correct method.

There should have been an error if `Guild.fetchMember()` didn't pass, but it could have silently failed or something and just set the value to `undefined`, which has no function `.send()`, hence the error.