### PR TITLE
Plausible fix for original error

### DIFF
--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -14,7 +14,7 @@ module.exports = async (reaction, user) => {
 
   let mcusername = reaction.message.embeds[0].fields[0].value; // shadowolfyt
   let server = reaction.message.embeds[0].fields[1].value; // servers
-  let discordid = reaction.message.embeds[0].fields[3].value; // discord id
+  let discordid = reaction.message.embeds[0].fields[2].value; // user mention (a User class object)
   let requesteduser = message.guild.fetchMember(discordid);
   // let requesteduser = client.users.get(discordid);
 


### PR DESCRIPTION
The original error said that `requesteduser.send is not a function`, which I assumed was an issue with `message.guild.fetchMemeber()`. Turns out I was on the stable version of the Discord.js documentation, but the version used is 11.5.1. Turns out, `fetchMember()` _is in fact_ a valid function in version 11.5.1.

The `fetchMember()` method requires a `User` class argument, which it was getting a string argument. My theory was that using the mention from the embed (which was a `User` class when sent) could work and make `fetchMember()` work correctly.

Hopefully this works!